### PR TITLE
Follow symlinks to executable

### DIFF
--- a/bin/awsm
+++ b/bin/awsm
@@ -3,7 +3,11 @@ set -euo pipefail
 
 function realpath { echo $(cd $(dirname $1); pwd)/$(basename $1); }
 
-BIN_FILE=$(realpath $(readlink ${BASH_SOURCE[0]}))
+BIN_FILE=$(realpath ${BASH_SOURCE[0]})
+if [ -L $BIN_FILE ]; then
+  BIN_FILE=$(readlink ${BIN_FILE})
+fi
+
 INSTALL_DIR=$(realpath `dirname ${BIN_FILE}`/../)
 : ${AWSM_HOME=$HOME/.awsm}
 : ${AWSM_CONFIG=$AWSM_HOME/config}

--- a/bin/awsm
+++ b/bin/awsm
@@ -3,7 +3,7 @@ set -euo pipefail
 
 function realpath { echo $(cd $(dirname $1); pwd)/$(basename $1); }
 
-BIN_FILE=$(realpath ${BASH_SOURCE[0]})
+BIN_FILE=$(realpath $(readlink ${BASH_SOURCE[0]}))
 INSTALL_DIR=$(realpath `dirname ${BIN_FILE}`/../)
 : ${AWSM_HOME=$HOME/.awsm}
 : ${AWSM_CONFIG=$AWSM_HOME/config}


### PR DESCRIPTION
This fixes #7 by following symlinks to the awsm executable, which in
turn causes the script to look in the right place for `lib`.

readlink is used to follow any symlinks, and has been tested on Linux
Mint 18 and OSX 10.11.5.
