### PR TITLE
Add error message if fuzzy filter is missing

### DIFF
--- a/lib/awsm.sh
+++ b/lib/awsm.sh
@@ -1,4 +1,10 @@
 : ${FUZZY_FILTER="fzf"}
+
+if [ ! -e "$FUZZY_FILTER" ]; then
+  >&2 echo default filter $FUZZY_FILTER not found, please specify with FUZZY_FILTER
+  exit 1
+fi
+
 : ${AWSM_SSH_USER=""}
 : ${AWSM_AWS_CONNECT_IP="private"}
 


### PR DESCRIPTION
This fixes #9 by adding a helpful error message, suggesting the user set
FUZZY_FILTER if the default filter (fzf) isn't on $PATH.
