### PR TITLE
request mfa code first so not to screw up awsm output.

### DIFF
--- a/bin/awsm
+++ b/bin/awsm
@@ -38,7 +38,17 @@ function source_plugins {
   fi
 }
 
+function fetch_mfa {
+  $(aws configure list > /dev/null 2>&1)
+  return_code=$?
+
+  if [ $return_code != 0 ]; then
+    exit $return_code
+  fi
+}
+
 load_awsm_core
 load_config
+fetch_mfa
 source_plugins
 $@


### PR DESCRIPTION
this should request entry of mfa code if require first and not mess up the awsm output.
